### PR TITLE
Resource API

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -29,6 +29,7 @@ services:
          - "./gunicorn.conf.py:/etc/gunicorn.conf.py"
          - "./migrations:/fslc_stream/migrations"
          - "./fslc_stream/:/fslc_stream/fslc_stream"
+         - "./media:/var/stream:rw"
       depends_on: postgres
    postgres:
       restart: "always"

--- a/fslc_stream/auth.py
+++ b/fslc_stream/auth.py
@@ -1,11 +1,13 @@
 from functools import wraps
 import typing
 from os import environ
-from flask import g, request, make_response
+from uuid import UUID
+from flask import current_app, g, request, make_response
 import jwt
 from jwt import PyJWKClient
 import requests
 
+from fslc_stream.db.models import Stream
 from fslc_stream.types import AuthorizationLevel
 
 OIDC_CLIENT_ID = environ["OIDC_CLIENT_ID"]
@@ -46,6 +48,7 @@ def requires_authorization(required_level: AuthorizationLevel = AuthorizationLev
                 return make_response("JWT is expired.", 401)
 
             g.payload = payload
+            g.subject = g.payload["sub"]
 
             auth_level = get_auth_level(payload["roles"])
 
@@ -68,3 +71,6 @@ def teardown_payload(_):
         g.pop("payload")
     if "auth_level" in g:
         g.pop("auth_level")
+
+def can_control_stream(stream: Stream):
+    return g.auth_level == AuthorizationLevel.ADMIN or stream.presenter == g.subject

--- a/fslc_stream/db/models.py
+++ b/fslc_stream/db/models.py
@@ -33,7 +33,9 @@ class Event(Base):
 
     streams: Mapped[List["Stream"]] = relationship(back_populates="event", passive_deletes=True)
 
-    def as_json(self, with_streams=False) -> dict[str, Any]:
+    resources: Mapped[List["Resource"]] = relationship(back_populates="event", passive_deletes=True)
+
+    def as_json(self, with_streams=False, with_resources=False) -> dict[str, Any]:
         result = {
             "id": str(self.id),
             "create_time": self.create_time.timestamp(),
@@ -46,6 +48,9 @@ class Event(Base):
 
         if with_streams:
             result["streams"] = [s.as_json() for s in self.streams]
+
+        if with_resources:
+            result["resources"] = [r.as_json() for r in self.resources]
 
         return result
 
@@ -118,6 +123,8 @@ class Stream(Base):
     event_id: Mapped[Optional[UUID]] = mapped_column(sa.ForeignKey("event.id", ondelete="SET NULL"))
     event: Mapped["Event"] = relationship(back_populates="streams", passive_deletes=True)
 
+    resources: Mapped[List["Resource"]] = relationship(back_populates="stream", passive_deletes=True)
+
     def as_json(self, with_event=False) -> dict[str, Any]:
         result = {
             "id": str(self.id),
@@ -175,5 +182,36 @@ class Stream(Base):
                 result.end_time = parse_datetime_permissive(data["end_time"])
             if "process_time" in data:
                 result.process_time = parse_datetime_permissive(data["process_time"])
+
+        return result
+
+class Resource(Base):
+    __tablename__ = "resource"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()")
+    )
+    create_time: Mapped[datetime] = mapped_column(server_default=sa.text("now()"))
+    filename: Mapped[str] = mapped_column(sa.String(32))
+    filesize: Mapped[int]
+    content_hash: Mapped[bytes]
+
+    event_id: Mapped[Optional[UUID]] = mapped_column(sa.ForeignKey("event.id"))
+    event: Mapped[Optional["Event"]] = relationship(back_populates="resources", passive_deletes=True)
+
+    stream_id: Mapped[Optional[UUID]] = mapped_column(sa.ForeignKey("stream.id"))
+    stream: Mapped[Optional["Stream"]] = relationship(back_populates="resources", passive_deletes=True)
+
+    def as_json(self) -> dict[str, Any]:
+        result = {
+            "id": str(self.id),
+            "create_time": self.create_time.timestamp(),
+            "filename": self.filename,
+            "filesize": self.filesize,
+            "content_hash": self.content_hash.hex(),
+            "stream_id": self.stream_id,
+            "event_id": self.event_id
+        }
 
         return result

--- a/fslc_stream/db/models.py
+++ b/fslc_stream/db/models.py
@@ -125,7 +125,7 @@ class Stream(Base):
 
     resources: Mapped[List["Resource"]] = relationship(back_populates="stream", passive_deletes=True)
 
-    def as_json(self, with_event=False) -> dict[str, Any]:
+    def as_json(self, with_event=False, with_resources=False) -> dict[str, Any]:
         result = {
             "id": str(self.id),
             "create_time": self.create_time.timestamp(),
@@ -141,6 +141,9 @@ class Stream(Base):
             result["event"] = self.event.as_json()
         else:
             result["event_id"] = self.event_id
+
+        if with_resources:
+            result["resources"] = [r.as_json() for r in self.resources]
 
         return result
 

--- a/fslc_stream/event.py
+++ b/fslc_stream/event.py
@@ -1,12 +1,16 @@
-from uuid import UUID
+from os import makedirs, remove
+from uuid import UUID, uuid4
+import hashlib
 from flask import Blueprint, current_app, make_response, request
 import icalendar
 from sqlalchemy import delete, select
+from werkzeug.utils import secure_filename
 
 from fslc_stream.auth import requires_authorization
 from fslc_stream.db.context import db
-from fslc_stream.db.models import Event, SerializationError, Stream
+from fslc_stream.db.models import Event, Resource, SerializationError, Stream
 from fslc_stream.types import AuthorizationLevel
+from fslc_stream.upload_utils import ResourceUploadError, save_resource
 from fslc_stream.utils import parse_datetime_permissive
 
 
@@ -36,6 +40,7 @@ def new_event():
 @blueprint.get("")
 def get_events():
     with_streams = "with-streams" in request.args
+    with_resources = "with-resources" in request.args
 
     format = request.args.get("format", "json")
 
@@ -71,7 +76,7 @@ def get_events():
         return make_response("No events in time frame.", 404)
 
     if format == "json":
-        return [e.as_json(with_streams) for e in events]
+        return [e.as_json(with_streams, with_resources) for e in events]
     elif format == "ics":
         result = icalendar.Calendar()
         result.add("x-wr-calname", "USU FSLC Events")
@@ -88,6 +93,7 @@ def get_events():
 @blueprint.get("/<uuid:uuid>")
 def get_event(uuid: UUID):
     with_streams = "with-streams" in request.args
+    with_resources = "with-resources" in request.args
 
     format = request.args.get("format", "json")
 
@@ -101,7 +107,7 @@ def get_event(uuid: UUID):
         return make_response("No such event.", 404)
 
     if format == "json":
-        return event.as_json(with_streams)
+        return event.as_json(with_streams, with_resources)
     elif format == "ics":
         result = icalendar.Calendar()
         result.add_component(event.as_ics())
@@ -189,3 +195,60 @@ def add_stream(uuid: UUID):
     db.session.commit()
 
     return make_response(stream.as_json())
+
+
+@blueprint.get("/<uuid:uuid>/resource")
+def list_resources(uuid: UUID):
+    query = select(Resource).where(Resource.event_id == uuid)
+    scalars = db.session.scalars(query)
+
+    return make_response([r.as_json() for r in scalars])
+
+
+@blueprint.post("/<uuid:eid>/resource")
+@requires_authorization(required_level=AuthorizationLevel.ADMIN)
+def upload_resource(eid: UUID):
+    query = select(Event).where(Event.id == eid)
+    if db.session.scalar(query) is None:
+        return make_response("No such event.", 400)
+
+    current_app.logger.error(request.files)
+    if len(request.files) != 1:
+        return make_response("Please upload exactly one file.", 400)
+
+    storage = next(iter(request.files.values()))
+
+    try:
+        res = save_resource(storage)
+    except ResourceUploadError as e:
+        return make_response(e.message, 400)
+
+    res.event_id = eid
+
+    db.session.add(res)
+    db.session.commit()
+
+    return make_response(res.as_json())
+
+
+@blueprint.delete("/<uuid:eid>/resource/<uuid:rid>")
+@requires_authorization(required_level=AuthorizationLevel.ADMIN)
+def delete_resource(eid: UUID, rid: UUID):
+    query = select(Resource).where(Resource.id == rid)
+    res = db.session.scalar(query)
+    if res is None:
+        return make_response("No such resource.", 400)
+
+    if res.event_id != eid:
+        return make_response("Event is incorrect.", 400)
+
+    dir = f"/var/stream/resources/{rid}"
+    path = f"{dir}/{res.filename}"
+
+    remove(path)
+    remove(dir)
+
+    db.session.delete(res)
+    db.session.commit()
+
+    return {"ok": "deleted"}

--- a/fslc_stream/event.py
+++ b/fslc_stream/event.py
@@ -212,7 +212,6 @@ def upload_resource(eid: UUID):
     if db.session.scalar(query) is None:
         return make_response("No such event.", 400)
 
-    current_app.logger.error(request.files)
     if len(request.files) != 1:
         return make_response("Please upload exactly one file.", 400)
 

--- a/fslc_stream/event.py
+++ b/fslc_stream/event.py
@@ -1,4 +1,4 @@
-from os import makedirs, remove
+from os import makedirs, remove, rmdir
 from uuid import UUID, uuid4
 import hashlib
 from flask import Blueprint, current_app, make_response, request
@@ -163,7 +163,7 @@ def patch_event(uuid: UUID):
             return make_response("invalid end time", 400)
 
     db.session.commit()
-    return event.as_json(with_streams=True)
+    return event.as_json(with_streams=True, with_resources=True)
 
 
 @blueprint.get("/<uuid:uuid>/stream")
@@ -246,7 +246,7 @@ def delete_resource(eid: UUID, rid: UUID):
     path = f"{dir}/{res.filename}"
 
     remove(path)
-    remove(dir)
+    rmdir(dir)
 
     db.session.delete(res)
     db.session.commit()

--- a/fslc_stream/fslc_stream.py
+++ b/fslc_stream/fslc_stream.py
@@ -14,6 +14,8 @@ def create_app():
     from fslc_stream.api import blueprint as api_blueprint
     app = StreamServerFlask(__name__)
 
+    app.config['MAX_CONTENT_LENGTH'] = 100 * 1024 * 1024
+
     if "SQLALCHEMY_DATABASE_URI" in environ:
         app.config["SQLALCHEMY_DATABASE_URI"] = environ["SQLALCHEMY_DATABASE_URI"]
     else:

--- a/fslc_stream/stream.py
+++ b/fslc_stream/stream.py
@@ -1,4 +1,4 @@
-from os import remove
+from os import remove, rmdir
 from uuid import UUID
 from flask import Blueprint, current_app, g, request, make_response
 from sqlalchemy import Result, and_, delete, select
@@ -130,7 +130,6 @@ def upload_resource(sid: UUID):
     if stream is None:
         return make_response("No such event.", 400)
 
-    current_app.logger.error(request.files)
     if len(request.files) != 1:
         return make_response("Please upload exactly one file.", 400)
 
@@ -171,7 +170,7 @@ def delete_resource(sid: UUID, rid: UUID):
     path = f"{dir}/{res.filename}"
 
     remove(path)
-    remove(dir)
+    rmdir(dir)
 
     db.session.delete(res)
     db.session.commit()

--- a/fslc_stream/stream.py
+++ b/fslc_stream/stream.py
@@ -135,7 +135,7 @@ def upload_resource(sid: UUID):
         return make_response("Please upload exactly one file.", 400)
 
     if not can_control_stream(stream):
-        pass
+        return make_response("You are not authorized to modify this stream.", 401)
 
     storage = next(iter(request.files.values()))
 
@@ -160,8 +160,12 @@ def delete_resource(sid: UUID, rid: UUID):
     if res is None:
         return make_response("No such resource.", 400)
 
-    if res.stream_id != sid:
+    stream = res.stream
+    if stream is None or stream.id != sid:
         return make_response("Event is incorrect.", 400)
+
+    if not can_control_stream(stream):
+        return make_response("You are not authorized to modify this stream.", 401)
 
     dir = f"/var/stream/resources/{rid}"
     path = f"{dir}/{res.filename}"

--- a/fslc_stream/stream.py
+++ b/fslc_stream/stream.py
@@ -1,10 +1,12 @@
+from os import remove
 from uuid import UUID
-from flask import Blueprint, g, request, make_response
+from flask import Blueprint, current_app, g, request, make_response
 from sqlalchemy import Result, and_, delete, select
-from fslc_stream.auth import requires_authorization
+from fslc_stream.auth import can_control_stream, requires_authorization
 from fslc_stream.db.context import db
-from fslc_stream.db.models import SerializationError, Stream
+from fslc_stream.db.models import Resource, SerializationError, Stream
 from fslc_stream.types import AuthorizationLevel
+from fslc_stream.upload_utils import ResourceUploadError, save_resource
 
 
 blueprint = Blueprint("stream_api", __name__)
@@ -117,3 +119,57 @@ def get_stream_token(uuid: UUID):
         return make_response("This stream has no token.", 404)
 
     return {"token": str(uuid) + "." + stream.token}
+
+
+@blueprint.post("/<uuid:sid>/resource")
+@requires_authorization(required_level=AuthorizationLevel.USER)
+def upload_resource(sid: UUID):
+    query = select(Stream).where(Stream.id == sid)
+    stream = db.session.scalar(query)
+
+    if stream is None:
+        return make_response("No such event.", 400)
+
+    current_app.logger.error(request.files)
+    if len(request.files) != 1:
+        return make_response("Please upload exactly one file.", 400)
+
+    if not can_control_stream(stream):
+        pass
+
+    storage = next(iter(request.files.values()))
+
+    try:
+        res = save_resource(storage)
+    except ResourceUploadError as e:
+        return make_response(e.message, 400)
+
+    res.stream_id = sid
+
+    db.session.add(res)
+    db.session.commit()
+
+    return make_response(res.as_json())
+
+
+@blueprint.delete("/<uuid:sid>/resource/<uuid:rid>")
+@requires_authorization(required_level=AuthorizationLevel.USER)
+def delete_resource(sid: UUID, rid: UUID):
+    query = select(Resource).where(Resource.id == rid)
+    res = db.session.scalar(query)
+    if res is None:
+        return make_response("No such resource.", 400)
+
+    if res.stream_id != sid:
+        return make_response("Event is incorrect.", 400)
+
+    dir = f"/var/stream/resources/{rid}"
+    path = f"{dir}/{res.filename}"
+
+    remove(path)
+    remove(dir)
+
+    db.session.delete(res)
+    db.session.commit()
+
+    return {"ok": "deleted"}

--- a/fslc_stream/stream.py
+++ b/fslc_stream/stream.py
@@ -47,12 +47,13 @@ def current_streams():
 @blueprint.get("/<uuid:uuid>")
 def get_stream(uuid: UUID):
     with_event = "with-event" in request.args
+    with_resources = "with-resources" in request.args
     query = select(Stream).where(Stream.id == uuid)
     stream = db.session.scalar(query)
 
     if stream is None:
         return make_response("No such stream.", 404)
-    return stream.as_json(with_event)
+    return stream.as_json(with_event, with_resources)
 
 
 @blueprint.delete("/<uuid:uuid>")
@@ -119,6 +120,14 @@ def get_stream_token(uuid: UUID):
         return make_response("This stream has no token.", 404)
 
     return {"token": str(uuid) + "." + stream.token}
+
+
+@blueprint.get("/<uuid:uuid>/resource")
+def list_resources(uuid: UUID):
+    query = select(Resource).where(Resource.stream_id == uuid)
+    scalars = db.session.scalars(query)
+
+    return make_response([r.as_json() for r in scalars])
 
 
 @blueprint.post("/<uuid:sid>/resource")

--- a/fslc_stream/upload_utils.py
+++ b/fslc_stream/upload_utils.py
@@ -1,0 +1,50 @@
+import hashlib
+from os import makedirs
+from uuid import uuid4
+
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+from fslc_stream.db.models import Resource
+
+
+class ResourceUploadError(Exception):
+    message: str
+
+    def __init__(self, message: str):
+        self.message = message
+
+
+def save_resource(storage: FileStorage) -> Resource:
+    rid = uuid4();
+
+    if storage.filename is None:
+        raise ResourceUploadError("The file must have a filename.")
+
+    real_filename = secure_filename(storage.filename)
+
+    if not (1 <= len(real_filename) <= 100):
+        raise ResourceUploadError("The filename must be between 1 and 100 characters.")
+
+    dir = f"/var/stream/resources/{rid}"
+    path = f"{dir}/{real_filename}"
+    makedirs(dir, exist_ok=True)
+    f = open(path, "wb") 
+    # simultaneously build up a hash and save the file
+    hash = hashlib.sha256()
+    buf = bytearray(b'\x00'*4096)
+    size = 0
+
+    while bytesread := storage.stream.readinto(buf):
+        hash.update(buf)
+        f.write(buf)
+        size += bytesread;
+
+    f.close()
+
+    return Resource(
+        id=rid,
+        filename=real_filename,
+        filesize=size,
+        content_hash = hash.digest(),
+    )

--- a/migrations/versions/873329794b00_add_resources.py
+++ b/migrations/versions/873329794b00_add_resources.py
@@ -1,0 +1,34 @@
+"""add resources
+
+Revision ID: 873329794b00
+Revises: 976401935155
+Create Date: 2025-11-21 07:48:50.675404
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '873329794b00'
+down_revision = '976401935155'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "resource",
+        sa.Column("id", sa.UUID, primary_key=True, server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("create_time", sa.DateTime, server_default=sa.text("now()"), nullable=False),
+        sa.Column("filename", sa.String, nullable=False),
+        sa.Column("filesize", sa.Integer, nullable=False),
+        sa.Column("content_hash", sa.LargeBinary, unique=True, nullable=False),
+        sa.Column("event_id", sa.UUID, sa.ForeignKey("event.id")),
+        sa.Column("stream_id", sa.UUID, sa.ForeignKey("stream.id")),
+        sa.CheckConstraint("(event_id IS NULL AND stream_id IS NOT NULL) OR (event_id IS NOT NULL AND stream_id IS NULL)", name="stream_or_event_id")
+    )
+
+
+def downgrade():
+    op.drop_table("resource")

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,4 +3,5 @@ FROM docker.io/alfg/nginx-rtmp
 EXPOSE 80
 EXPOSE 1935
 
+COPY ./safe.types /etc/nginx/
 COPY ./scripts /scripts/

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -73,5 +73,11 @@ http {
 			alias /var/stream/recordings/;
 			autoindex on;
 		}
+
+		location /resources/ {
+			default_type text/plain;
+			alias /var/stream/resources/;
+			autoindex on;
+		}
 	}
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -75,6 +75,7 @@ http {
 		}
 
 		location /resources/ {
+			include safe.types;
 			default_type text/plain;
 			alias /var/stream/resources/;
 			autoindex on;

--- a/nginx/safe.types
+++ b/nginx/safe.types
@@ -1,0 +1,52 @@
+# minimal types list that should allow for types
+# that the browser can preview to be shown but
+# should prevent anything that may cause code
+# to be run.
+
+types {
+	image/gif                                        gif;
+	image/jpeg                                       jpeg jpg;
+	application/atom+xml                             atom;
+	application/rss+xml                              rss;
+
+	image/avif                                       avif;
+	image/png                                        png;
+	image/svg+xml                                    svg svgz;
+	image/tiff                                       tif tiff;
+	image/vnd.wap.wbmp                               wbmp;
+	image/webp                                       webp;
+	image/x-icon                                     ico;
+	image/x-jng                                      jng;
+	image/x-ms-bmp                                   bmp;
+
+	application/json                                 json;
+	application/pdf                                  pdf;
+	application/postscript                           ps eps ai;
+	application/x-7z-compressed                      7z;
+	application/zip                                  zip;
+
+	application/octet-stream                         bin exe dll;
+	application/octet-stream                         deb;
+	application/octet-stream                         dmg;
+	application/octet-stream                         iso img;
+	application/octet-stream                         msi msp msm;
+
+	audio/midi                                       mid midi kar;
+	audio/mpeg                                       mp3;
+	audio/ogg                                        ogg;
+	audio/x-m4a                                      m4a;
+	audio/x-realaudio                                ra;
+
+	video/3gpp                                       3gpp 3gp;
+	video/mp2t                                       ts;
+	video/mp4                                        mp4;
+	video/mpeg                                       mpeg mpg;
+	video/quicktime                                  mov;
+	video/webm                                       webm;
+	video/x-flv                                      flv;
+	video/x-m4v                                      m4v;
+	video/x-mng                                      mng;
+	video/x-ms-asf                                   asx asf;
+	video/x-ms-wmv                                   wmv;
+	video/x-msvideo                                  avi;
+}


### PR DESCRIPTION
Allows users to upload resources (files) to the server.

This PR adds a table of resources to the database. Each resource can be associated with either an event or a stream.

Endpoints have been added that allow users to submit a resource to an event or stream. Options have been added to the existing GET endpoints for events and streams which allow the user to also request the list of resources.

The fslc-stream container is also newly given access to the storage volume so that it can add and delete files therefrom.