### PR TITLE
fix volumes in production docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
          - "5000:5000"
       volumes:
          - "./gunicorn.conf.py:/etc/gunicorn.conf.py"
-         - "./migrations:/fslc-stream/migrations"
+         - "./media:/var/stream:rw"
       depends_on:
          - postgres
    postgres:


### PR DESCRIPTION
Remove the old migrations volume (these are part of the image now) and add the media volume (required because of resource api)